### PR TITLE
bugfix: empty object case does not evaluate to truthy false

### DIFF
--- a/lib/rules/checks.js
+++ b/lib/rules/checks.js
@@ -30,7 +30,7 @@ checks = function(context) {
       var node = map[name];
       var params = getFunctionParams(node);
 
-      var body = node.body ? node.body.body : {};
+      var body = node.body ? node.body.body : null;
       var checkMap = (body || []).reduce(function check(checkMap, node) {
         if (!node) {
           return checkMap;


### PR DESCRIPTION
[Line 34](https://github.com/East5th/check-checker/compare/master...gevou:master#diff-cff607889bbceee85d9f847570a4296aL34) throws the following error when `body` is empty because `(body || []` evaluates to `{}`. 

`packages/check-checker/lib/rules/checks.js:34:1: (body || []).reduce is not a function`...(etc)